### PR TITLE
use head of webodf for testing CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "Compiling in the source directory is not supported. Use for example 'mkdir build; cd build; cmake ..'.")
 endif (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 
+MESSAGE ( STATUS "Building ViewerJS version: ${VIEWERJS_VERSION}" )
 # Tools must be obtained to work with:
 include (ExternalProject)
 


### PR DESCRIPTION
one change included in this PR  is to not build node.js but just require it on the build-host.
(ci was failing on ARG_MAX on the ci-host)
