### PR TITLE
Add compatibility.js

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ ExternalProject_Add(
     BUILD_COMMAND node <SOURCE_DIR>/make.js generic
     INSTALL_COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/generic/build/pdf.js ${CMAKE_BINARY_DIR}/viewer/pdf.js
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/generic/build/pdf.worker.js ${CMAKE_BINARY_DIR}/viewer/pdf.worker.js
+    COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/build/generic/web/compatibility.js ${CMAKE_BINARY_DIR}/viewer/compatibility.js
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/web/pdf_find_bar.js ${CMAKE_BINARY_DIR}/viewer/pdf_find_bar.js
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/web/pdf_find_controller.js ${CMAKE_BINARY_DIR}/viewer/pdf_find_controller.js
     COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/web/ui_utils.js ${CMAKE_BINARY_DIR}/viewer/ui_utils.js

--- a/PDFViewerPlugin.js
+++ b/PDFViewerPlugin.js
@@ -54,7 +54,8 @@ function PDFViewerPlugin() {
     function init(callback) {
         var pdfLib, textLayerLib, pluginCSS;
 
-        loadScript('./pdf.js', function () {
+        loadScript('./compatibility.js', function () {
+            loadScript('./pdf.js');
             loadScript('./pdf_find_bar.js');
             loadScript('./pdf_find_controller.js');
             loadScript('./ui_utils.js');


### PR DESCRIPTION
`compatibility.js` that ships with pdfjs should fix numerous issues with displaying on IE and should fix complete breakage upon initialization with Safari.
