### PR TITLE
Using content-type for choosing the viewer instead of extension

### DIFF
--- a/PluginLoader.js
+++ b/PluginLoader.js
@@ -1,24 +1,20 @@
 /**
- * @license
- * Copyright (C) 2012 KO GmbH <copyright@kogmbh.com>
- *
- * @licstart
- * The JavaScript code in this page is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Affero General Public License
- * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.  The code is distributed
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this code.  If not, see <http://www.gnu.org/licenses/>.
- *
- * As additional permission under GNU AGPL version 3 section 7, you
- * may distribute non-source (e.g., minimized or compacted) forms of
- * that code without the copy of the GNU GPL normally required by
- * section 4, provided you include this license notice and a URL
- * through which recipients can access the Corresponding Source.
- *
+ * @license Copyright (C) 2012 KO GmbH <copyright@kogmbh.com>
+ * 
+ * @licstart The JavaScript code in this page is free software: you can
+ *           redistribute it and/or modify it under the terms of the GNU Affero
+ *           General Public License (GNU AGPL) as published by the Free Software
+ *           Foundation, either version 3 of the License, or (at your option)
+ *           any later version. The code is distributed WITHOUT ANY WARRANTY;
+ *           without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ *           A PARTICULAR PURPOSE. See the GNU AGPL for more details.
+ * 
+ * As additional permission under GNU AGPL version 3 section 7, you may
+ * distribute non-source (e.g., minimized or compacted) forms of that code
+ * without the copy of the GNU GPL normally required by section 4, provided you
+ * include this license notice and a URL through which recipients can access the
+ * Corresponding Source.
+ * 
  * As a special exception to the AGPL, any HTML file which merely makes function
  * calls to this code, and for that purpose includes it by reference shall be
  * deemed a separate work for copyright law purposes. In addition, the copyright
@@ -26,61 +22,82 @@
  * software libraries that are released under the GNU LGPL. You may copy and
  * distribute such a system following the terms of the GNU AGPL for this code
  * and the LGPL for the libraries. If you modify this code, you may extend this
- * exception to your version of the code, but you are not obligated to do so.
- * If you do not wish to do so, delete this exception statement from your
- * version.
- *
+ * exception to your version of the code, but you are not obligated to do so. If
+ * you do not wish to do so, delete this exception statement from your version.
+ * 
  * This license applies to this entire compilation.
  * @licend
  * @source: http://viewerjs.org/
- * @source: http://github.com/kogmbh/Viewer.js
+ * @source: http://github.com/thz/Viewer.js
  */
 
-/*global document, window, Viewer, ODFViewerPlugin, PDFViewerPlugin*/
+/* global document, window, Viewer, ODFViewerPlugin, PDFViewerPlugin */
 
 var viewer;
 
 function loadPlugin(pluginName, callback) {
-    "use strict";
-    var script, style;
+	"use strict";
+	var script, style;
 
-    // Load script
-    script = document.createElement('script');
-    script.async = false;
-    script.onload = callback;
-    script.src = pluginName + '.js';
-    script.type = 'text/javascript';
-    document.getElementsByTagName('head')[0].appendChild(script);
+	// Load script
+	script = document.createElement('script');
+	script.async = false;
+	script.onload = callback;
+	script.src = pluginName + '.js';
+	script.type = 'text/javascript';
+	document.getElementsByTagName('head')[0].appendChild(script);
+}
+
+function createXMLHttpRequest(){
+	var xmlhttp;
+
+	if (window.XMLHttpRequest) {
+		// code for IE7+, Firefox, Chrome, Opera,Safari
+		xmlhttp = new XMLHttpRequest();
+	} else {
+		// code for IE6, IE5
+		xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
+	}
+	
+	return xmlhttp;
 }
 
 function loadDocument(documentUrl) {
-    "use strict";
+	"use strict";
 
-    if (documentUrl) {
-        var extension = documentUrl.split('.').pop(),
-            Plugin;
-        extension = extension.toLowerCase();
-        
-        switch (extension) {
-        case 'odt':
-        case 'odp':
-        case 'ods':
-        case 'fodt':
-            loadPlugin('./ODFViewerPlugin', function () {
-                Plugin = ODFViewerPlugin;
-            });
-            break;
-        case 'pdf':
-            loadPlugin('./PDFViewerPlugin', function () {
-                Plugin = PDFViewerPlugin;
-            });
-            break;
-        }
+	if (documentUrl) {
+		var xmlhttp = createXMLHttpRequest();
 
-        window.onload = function () {
-            if (Plugin) {
-                viewer = new Viewer(new Plugin());
-            }
-        };
-    }
+		xmlhttp.onreadystatechange = function() {
+			//readystate === 2 --> Headers received!
+			if (xmlhttp.readyState === 2) {
+				var extension = this.getResponseHeader('content-type');
+
+				var Plugin;
+
+				switch (extension) {
+				case 'application/vnd.oasis.opendocument.text':
+				case 'application/vnd.oasis.opendocument.presentation':
+				case 'application/vnd.oasis.opendocument.spreadsheet':
+					loadPlugin('./ODFViewerPlugin', function() {
+						Plugin = ODFViewerPlugin;
+						viewer = new Viewer(new Plugin());
+					});
+					break;
+				case 'application/pdf':
+					loadPlugin('./PDFViewerPlugin', function() {
+						Plugin = PDFViewerPlugin;
+						viewer = new Viewer(new Plugin());
+					});
+					break;
+				}
+
+				//Abort the download of the document, in this phase we only need the content-type
+				this.abort();
+			}
+		};
+
+		xmlhttp.open("GET", documentUrl.substring(1), true);
+		xmlhttp.send();
+	}
 }


### PR DESCRIPTION
With the current implementation of the loadDocument function it's possible to use Viewer.js with a URL in this form: http://server/path/file.pdf. If when have a dynamic file, with a URL like this http://server/myscript.php the viewer,js doesn't work. This is because the selection of the viewer is based on the extension of the file. I used a AJAX request to get the content-type of the file, in this way
we can use viewer.js with REST services. 