### PR TITLE
use the new official name "ViewerJS" consistently everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,13 +29,13 @@
 # This license applies to this entire compilation.
 # @licend
 # @source: http://viewerjs.org/
-# @source: http://github.com/kogmbh/Viewer.js
+# @source: http://github.com/kogmbh/ViewerJS
 # 
 
-project (Viewer.js)
+project (ViewerJS)
 cmake_minimum_required(VERSION 2.8.6)
 
-SET(OVERRULED_VIEWERJS_VERSION "" CACHE STRING "Viewer.JS Version to overrule")
+SET(OVERRULED_VIEWERJS_VERSION "" CACHE STRING "ViewerJS Version to overrule")
 IF (OVERRULED_VIEWERJS_VERSION)
     set (VIEWERJS_VERSION ${OVERRULED_VIEWERJS_VERSION})
 ELSE (OVERRULED_VIEWERJS_VERSION)

--- a/LICENSE
+++ b/LICENSE
@@ -32,4 +32,4 @@
  This license applies to this entire compilation.
  @licend
  @source: http://viewerjs.org/
- @source: http://github.com/kogmbh/Viewer.js
+ @source: http://github.com/kogmbh/ViewerJS

--- a/PDFViewerPlugin.js
+++ b/PDFViewerPlugin.js
@@ -33,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://viewerjs.org/
- * @source: http://github.com/kogmbh/Viewer.js
+ * @source: http://github.com/kogmbh/ViewerJS
  */
 
 /*global document, PDFJS, console, TextLayerBuilder*/

--- a/PluginLoader.js
+++ b/PluginLoader.js
@@ -33,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://viewerjs.org/
- * @source: http://github.com/kogmbh/Viewer.js
+ * @source: http://github.com/kogmbh/ViewerJS
  */
 
 /*global document, window, Viewer, ODFViewerPlugin, PDFViewerPlugin*/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Viewer.JS
+# ViewerJS
 
-Viewer.JS combines a number of excellent open source tools that are built on HTML and javascript. Viewer.JS was funded by [NLnet foundation](http://nlnet.nl) and developed by [KO GmbH](http://kogmbh.com).
+ViewerJS combines a number of excellent open source tools that are built on HTML and javascript. ViewerJS was funded by [NLnet foundation](http://nlnet.nl) and developed by [KO GmbH](http://kogmbh.com).
 
-The heavy lifting in Viewer.JS is done by these awesome projects:
+The heavy lifting in ViewerJS is done by these awesome projects:
 
 ### WebODF
 
@@ -18,8 +18,8 @@ You can find additional information, some usage guides, and live examples at [th
 
 ### License
 
-Viewer.JS is a Free Software project. All code is available under the AGPL.
+ViewerJS is a Free Software project. All code is available under the AGPL.
 
-If you are interested in using Viewer.JS in your commercial product
+If you are interested in using ViewerJS in your commercial product
 (and do not want to disclose your sources / obey AGPL),
 contact [KO GmbH](http://kogmbh.com) for a commercial license.

--- a/viewerjs-plugin-README.txt
+++ b/viewerjs-plugin-README.txt
@@ -6,15 +6,15 @@ Tested up to: 3.6.1
 Stable tag: 1.0
 
 
-This plugin embeds Viewer.JS into WordPress.
+This plugin embeds ViewerJS into WordPress.
 
 == Description ==
 This is a combination of WebODF and PDF.js.
-This plugin embeds Viewer.JS into WordPress. This is a combination of WebODF and PDF.js. See www.viewerjs.org for more details.
+This plugin embeds ViewerJS into WordPress. This is a combination of WebODF and PDF.js. See www.viewerjs.org for more details.
 
 == Usage ==
 
-Navigate to a Document file (ODF or PDF) in your WP blog's media library and press the button "Insert with Viewer.JS".
+Navigate to a Document file (ODF or PDF) in your WP blog's media library and press the button "Insert with ViewerJS".
 Alternatively you can manually insert the WordPress shortcode `[viewerjs /path-to-some-file.pdf]` to embed
 any `*.pdf`, `*.odt`, `*.odp`, or `*.ods` documents at that location.
 
@@ -22,7 +22,7 @@ The plugin also provides a settings panel for adjusting the width and height of 
 
 == Installation ==
 
-1. Upload the whole `viewer.js-plugin` directory and content to the `/wp-content/plugins/` directory
+1. Upload the whole `viewerjs-plugin` directory and content to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
 (or do the automatic stuff from the /wp-admin/...)


### PR DESCRIPTION
See also https://github.com/kogmbh/WebODF/pull/584

Fixes #45
