### PR TITLE
Put all files into a subfolder ViewerJS/ in the zip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,10 @@ ExternalProject_Add(
 
 add_custom_command(
     OUTPUT ${VIEWERZIP}
-    COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/viewer ${VIEWER_BUILD_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/PluginLoader.js ${VIEWER_BUILD_DIR}/PluginLoader.js
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/PDFViewerPlugin.js ${VIEWER_BUILD_DIR}/PDFViewerPlugin.js
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/PDFViewerPlugin.css ${VIEWER_BUILD_DIR}/PDFViewerPlugin.css
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/AGPL-3.0.txt ${VIEWER_BUILD_DIR}/AGPL-3.0.txt
+    COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_BINARY_DIR}/viewer ${VIEWER_BUILD_DIR}/ViewerJS
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/PluginLoader.js ${VIEWER_BUILD_DIR}/ViewerJS/PluginLoader.js
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/PDFViewerPlugin.js ${VIEWER_BUILD_DIR}/ViewerJS/PDFViewerPlugin.js
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/PDFViewerPlugin.css ${VIEWER_BUILD_DIR}/ViewerJS/PDFViewerPlugin.css
     COMMAND node ARGS ${WEBODF_SOURCE_DIR}/webodf/lib/runtime.js ${WEBODF_SOURCE_DIR}/webodf/tools/zipdir.js
     ${VIEWER_BUILD_DIR}
     ${VIEWERZIP}


### PR DESCRIPTION
All examples on viewerjs.org talk about using a folder named `ViewerJS`. But the zip currently is structured to have a toplevel folder named `/viewerjs-x.y.z` which then contains all files directly.
I can tell you that confuses a lot (e.g. when doing live coding demos during talks ;) ).

To spare people renaming that toplevel folder to `ViewerJS` to match the examples, instead that folder should exist already below the toplevel folder and contain all files as expected. So people can just `mv` that folder around, avoiding any typos. Example: `/viewerjs-0.2.1/ViewerJS/`
Keeping the toplevel folder as it is matches usual packaging patterns and avoids overwriting similar directories when unzipping, due to the namespacing.

Additional advantage: in the future we should put README and Howtos below the toplevel folder as well, those would then be nicely separated from the actual code folder.
