### PR TITLE
Bump to pick up v1.1.1 of PDF.js

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ ExternalProject_Add(
     INSTALL_COMMAND ""
 )
 
-set(PDFJS_VERSION v1.0.1040)
+set(PDFJS_VERSION v1.1.1)
 ExternalProject_Add(
     PDFjs
     GIT_REPOSITORY https://github.com/mozilla/pdf.js.git


### PR DESCRIPTION
Advance to latest release version of PDF.js 1.1.1 (March 17) vs the existing support for 1.0.1040 (January 3). 